### PR TITLE
Removed both network options from homescreen, and replaced with 'New …

### DIFF
--- a/allegroTest/allegroTest/Menu_display.cpp
+++ b/allegroTest/allegroTest/Menu_display.cpp
@@ -5,7 +5,7 @@ Menu_display::Menu_display(int windowWidth, int windowHeight)
 	:m_menuLoad(0),
 	m_windowWidth(windowWidth),
 	m_windowHeight(windowHeight),
-	m_homeScreenOption(3),
+	m_homeScreenOption(1), //'new game' option lit up by default
 	font(nullptr)
 {
 }
@@ -14,7 +14,7 @@ void Menu_display::load() //load all the resources for this display screen
 {
 	if(!m_menuLoad)
 	{
-		font = al_load_ttf_font("C:/Dev/allegro/Font/pirulen.ttf",25,0);
+		font = al_load_ttf_font("C:/Dev/allegro/Font/pirulen.ttf",35,0);
 		if(!font) { menuFail("Could not load 'pirulen.ttf'.\n"); }
 		m_menuLoad = true;
 	}
@@ -35,9 +35,8 @@ void Menu_display::update()
 	al_clear_to_color(al_map_rgb(30,30,30));
 	int c1R, c1G, c1B,
 		c2R, c2G, c2B,
-		c3R, c3G, c3B,
-		c4R, c4G, c4B;
-	c1R = c1G = c1B = c2R = c2G = c2B = c3R = c3G = c3B = c4R = c4G = c4B = 0;
+		c3R, c3G, c3B;
+	c1R = c1G = c1B = c2R = c2G = c2B = c3R = c3G = c3B = 0;
 
 	switch(m_homeScreenOption) //light up the selected option
 	{
@@ -50,16 +49,12 @@ void Menu_display::update()
 	case 3:
 		c3R = c3G = c3B = 190;
 		break;
-	case 4:
-		c4R = c4G = c4B = 190;
-		break;
 	}
 
 	//draw menu options
-	al_draw_text(font, al_map_rgb(c1R,c1G,c1B), m_windowWidth*0.5, m_windowHeight*0.2, ALLEGRO_ALIGN_CENTRE, "HOST MULTIPLAYER GAME");
-	al_draw_text(font, al_map_rgb(c2R,c2G,c2B), m_windowWidth*0.5, m_windowHeight*0.4, ALLEGRO_ALIGN_CENTRE, "JOIN MULTIPLAYER GAME");
-	al_draw_text(font, al_map_rgb(c3R,c3G,c3B), m_windowWidth*0.5, m_windowHeight*0.6, ALLEGRO_ALIGN_CENTRE, "SINGLE PLAYER");
-	al_draw_text(font, al_map_rgb(c4R,c4G,c4B), m_windowWidth*0.5, m_windowHeight*0.8, ALLEGRO_ALIGN_CENTRE, "QUIT");
+	al_draw_text(font, al_map_rgb(c1R,c1G,c1B), m_windowWidth*0.5, m_windowHeight*0.3, ALLEGRO_ALIGN_CENTRE, "NEW GAME");
+	al_draw_text(font, al_map_rgb(c2R,c2G,c2B), m_windowWidth*0.5, m_windowHeight*0.5, ALLEGRO_ALIGN_CENTRE, "LOAD GAME");
+	al_draw_text(font, al_map_rgb(c3R,c3G,c3B), m_windowWidth*0.5, m_windowHeight*0.7, ALLEGRO_ALIGN_CENTRE, "QUIT");
 }
 
 void Menu_display::menuFail(std::string failMessage)

--- a/allegroTest/allegroTest/Menu_logic.cpp
+++ b/allegroTest/allegroTest/Menu_logic.cpp
@@ -3,7 +3,7 @@
 
 Menu_logic::Menu_logic()
 	:m_menu(),
-	m_homeScreenOption(3) //single player option lit up by default
+	m_homeScreenOption(1) //'new game' option selected by default
 {
 }
 
@@ -27,30 +27,29 @@ int Menu_logic::keyPress(ALLEGRO_EVENT &keyPressed)
 	case ALLEGRO_KEY_UP:
 		{
 			m_homeScreenOption--;
-			if (m_homeScreenOption < 3) { m_homeScreenOption = 4; }
+			if (m_homeScreenOption < 1) { m_homeScreenOption = 3; }
 		}
 		break;
 	case ALLEGRO_KEY_DOWN:
 		{
 			m_homeScreenOption++;
-			if (m_homeScreenOption > 4) { m_homeScreenOption = 3; }
+			if (m_homeScreenOption > 3) { m_homeScreenOption = 1; }
 		}
 		break;
 	case ALLEGRO_KEY_ENTER:
 		{
 			switch(m_homeScreenOption)
 			{
+			case 1:
+				return 1; //Start new game (go to space screen)
 			case 2:
-				return 3; //Join server
+				return 1; //Load existing game (go to space screen)
 			case 3:
-				return 1; //Host on localhost or play single player
-			case 4:
 				return -1; //Quit
-			//setUpHost();
 			}
 		}
-	case ALLEGRO_KEY_ESCAPE:
-		return -1;
+	/*case ALLEGRO_KEY_ESCAPE:
+		return -1;*/
 	}
 	(*m_menu).setHomeScreenOption(m_homeScreenOption); //tell display which option to light up
 	return 0; //otherwise stay in menu


### PR DESCRIPTION
…Game' and 'Load Game' options. Refactored the effect of those options - currently they both just start new game (i.e. load to space screen).
