### PR TITLE
Fix escape menu

### DIFF
--- a/SpaceHorse/SpaceHorse/Load_game_logic.cpp
+++ b/SpaceHorse/SpaceHorse/Load_game_logic.cpp
@@ -48,7 +48,7 @@ GameMode Load_game_logic::keyPress(ALLEGRO_EVENT &keyPressed)
 				db.load(m_players->at(0));
 
 				//Indicate game has begun
-				m_gameStarted = true;
+				*m_gameStarted = true;
 
 				return GameMode::space;
 			}

--- a/SpaceHorse/SpaceHorse/Load_game_logic.cpp
+++ b/SpaceHorse/SpaceHorse/Load_game_logic.cpp
@@ -7,12 +7,13 @@ Load_game_logic::Load_game_logic()
 {
 }
 
-void Load_game_logic::load(Load_game_display &loadGame, std::vector<Player> &players)
+void Load_game_logic::load(Load_game_display &loadGame, std::vector<Player> &players, bool &gameStarted)
 {
 	loadGame.load();
 	m_players = &players;
 	m_loadGame = &loadGame;
 	m_numScreenOptions = (int)((*m_loadGame).getNumberSaveGames());
+	m_gameStarted = &gameStarted;
 }
 
 void Load_game_logic::unload()
@@ -45,6 +46,10 @@ GameMode Load_game_logic::keyPress(ALLEGRO_EVENT &keyPressed)
 				std::cout << "Loading game from " << (*m_loadGame).getSavedGames().at(m_homeScreenOption - 1) << std::endl;
 				Database db((*m_loadGame).getSavedGames().at(m_homeScreenOption - 1)); //Create new database connection, passing in the name of the savefile chosen
 				db.load(m_players->at(0));
+
+				//Indicate game has begun
+				m_gameStarted = true;
+
 				return GameMode::space;
 			}
 			if (m_homeScreenOption == m_numScreenOptions) //Go back to menu

--- a/SpaceHorse/SpaceHorse/Load_game_logic.h
+++ b/SpaceHorse/SpaceHorse/Load_game_logic.h
@@ -14,10 +14,11 @@ private:
 	int m_homeScreenOption;
 	int m_numScreenOptions;
 	std::vector<Player> *m_players;
+	bool *m_gameStarted;
 
 public:
 	Load_game_logic();
-	void load(Load_game_display &loadGame, std::vector<Player> &players);
+	void load(Load_game_display &loadGame, std::vector<Player> &players, bool &gameStarted);
 	void unload();
 	void update();
 	GameMode keyPress(ALLEGRO_EVENT &keyPressed);

--- a/SpaceHorse/SpaceHorse/Logic.cpp
+++ b/SpaceHorse/SpaceHorse/Logic.cpp
@@ -11,15 +11,17 @@ Logic::Logic()
 	m_space_logic(),
 	m_dock_logic(),
 	m_gameMode(GameMode::menu),
-	m_done(0)
+	m_done(0),
+	m_gameStarted(0)
 {
 	//load map
 	m_map.makeSolarSystem();
+	m_gameStarted = false;
 }
 
 void Logic::load(Display &display)
 {
-	m_menu_logic.load(display.getMenu());
+	m_menu_logic.load(display.getMenu(), m_gameStarted);
 }
 
 void Logic::update() 
@@ -134,13 +136,13 @@ void Logic::changeScreen(GameMode oldScreenMode, Display &display)
 	switch(m_gameMode)
 	{
 	case GameMode::menu: //passes the display to logic (for future manipulation/control) and tells logic to tell display to load resources (e.g. bitmaps, fonts, etc)
-		m_menu_logic.load(display.getMenu());
+		m_menu_logic.load(display.getMenu(), m_gameStarted);
 		break;
 	case GameMode::newGame:
-		m_new_game_logic.load(display.getNewGame()); //tells logic to tell old display to unload resources (e.g. bitmaps, etc)
+		m_new_game_logic.load(display.getNewGame(), m_gameStarted); //tells logic to tell old display to unload resources (e.g. bitmaps, etc)
 		break;
 	case GameMode::loadGame:
-		m_load_game_logic.load(display.getLoadGame(), m_players); //tells logic to tell old display to unload resources (e.g. bitmaps, etc)
+		m_load_game_logic.load(display.getLoadGame(), m_players, m_gameStarted); //tells logic to tell old display to unload resources (e.g. bitmaps, etc)
 		break;
 	case GameMode::saveGame:
 		m_save_game_logic.load(display.getSaveGame(), m_players); //tells logic to tell old display to unload resources (e.g. bitmaps, etc)

--- a/SpaceHorse/SpaceHorse/Logic.h
+++ b/SpaceHorse/SpaceHorse/Logic.h
@@ -27,6 +27,7 @@ private:
 	Dock_logic m_dock_logic;
 	GameMode m_gameMode;
 	bool m_done;
+	bool m_gameStarted;
 
 public:
 	Logic();

--- a/SpaceHorse/SpaceHorse/Menu_logic.cpp
+++ b/SpaceHorse/SpaceHorse/Menu_logic.cpp
@@ -7,10 +7,11 @@ Menu_logic::Menu_logic()
 {
 }
 
-void Menu_logic::load(Menu_display &menu)
+void Menu_logic::load(Menu_display &menu, bool &gameStarted)
 {
 	menu.load();
 	m_menu = &menu;
+	m_gameStarted = &gameStarted;
 }
 
 void Menu_logic::unload()
@@ -34,6 +35,16 @@ GameMode Menu_logic::keyPress(ALLEGRO_EVENT &keyPressed)
 		{
 			m_homeScreenOption++;
 			if (m_homeScreenOption > 4) { m_homeScreenOption = 1; }
+		}
+		break;
+	case ALLEGRO_KEY_ESCAPE:
+		{
+			if (m_gameStarted) {
+				return GameMode::space;
+			}
+			else {
+				; //Do nothing
+			}
 		}
 		break;
 	case ALLEGRO_KEY_ENTER:

--- a/SpaceHorse/SpaceHorse/Menu_logic.cpp
+++ b/SpaceHorse/SpaceHorse/Menu_logic.cpp
@@ -39,7 +39,7 @@ GameMode Menu_logic::keyPress(ALLEGRO_EVENT &keyPressed)
 		break;
 	case ALLEGRO_KEY_ESCAPE:
 		{
-			if (m_gameStarted) {
+			if (*m_gameStarted) {
 				return GameMode::space;
 			}
 			else {

--- a/SpaceHorse/SpaceHorse/Menu_logic.h
+++ b/SpaceHorse/SpaceHorse/Menu_logic.h
@@ -11,10 +11,11 @@ class Menu_logic
 private:
 	Menu_display *m_menu;
 	int m_homeScreenOption;
+	bool *m_gameStarted;
 
 public:
 	Menu_logic();
-	void load(Menu_display &menu);
+	void load(Menu_display &menu, bool &gameStarted);
 	void unload();
 	void update();
 	GameMode keyPress(ALLEGRO_EVENT &keyPressed);

--- a/SpaceHorse/SpaceHorse/New_game_logic.cpp
+++ b/SpaceHorse/SpaceHorse/New_game_logic.cpp
@@ -108,7 +108,7 @@ GameMode New_game_logic::keyPress(ALLEGRO_EVENT &keyPressed)
 			}
 
 			//Indicate game has begun
-			m_gameStarted = true;
+			*m_gameStarted = true;
 			
 			return GameMode::space; //Start new game (go to space screen)
 		}

--- a/SpaceHorse/SpaceHorse/New_game_logic.cpp
+++ b/SpaceHorse/SpaceHorse/New_game_logic.cpp
@@ -10,10 +10,11 @@ New_game_logic::New_game_logic()
 {
 }
 
-void New_game_logic::load(New_game_display &New_game)
+void New_game_logic::load(New_game_display &New_game, bool &gameStarted)
 {
 	New_game.load();
 	m_new_game = &New_game;
+	m_gameStarted = &gameStarted;
 }
 
 void New_game_logic::unload()
@@ -105,6 +106,9 @@ GameMode New_game_logic::keyPress(ALLEGRO_EVENT &keyPressed)
 				db.save(Player());
 				//db.get(); //Display database data
 			}
+
+			//Indicate game has begun
+			m_gameStarted = true;
 			
 			return GameMode::space; //Start new game (go to space screen)
 		}

--- a/SpaceHorse/SpaceHorse/New_game_logic.h
+++ b/SpaceHorse/SpaceHorse/New_game_logic.h
@@ -13,10 +13,11 @@ private:
 	std::string m_textEntered;
 	int m_newKey;
 	char m_newChar;
+	bool *m_gameStarted;
 
 public:
 	New_game_logic();
-	void load(New_game_display &newGame);
+	void load(New_game_display &newGame, bool &gameStarted);
 	void unload();
 	void update();
 	GameMode keyPress(ALLEGRO_EVENT &keyPressed);


### PR DESCRIPTION
Allowing to escape from the Menu, back to the game - as long as a game has been started already (new game, or loaded one).
